### PR TITLE
Minor updates to Makefiles and testWrappedPoint

### DIFF
--- a/tutorial1/Makefile
+++ b/tutorial1/Makefile
@@ -1,7 +1,7 @@
 all: test
 
 clean:
-	rm *.o *.so *.html
+	rm -f *.o *.so *.html
 
 clib1.so: clib1.o
 	gcc -shared -o libclib1.so clib1.o

--- a/tutorial2/Makefile
+++ b/tutorial2/Makefile
@@ -1,7 +1,7 @@
 all: point wrappedPoint line
 
 clean:
-	rm *.o *.so
+	rm -f *.o *.so *.html
 
 libpoint.so: Point.o
 	gcc -shared $^ -o $@
@@ -9,7 +9,7 @@ libpoint.so: Point.o
 libline.so: Point.o Line.o
 	gcc -shared $^ -o $@
 
-.o: .c
+%.o: %.c
 	gcc -c -Wall -Werror -fpic $^
 
 point: libpoint.so

--- a/tutorial2/testWrappedPoint.py
+++ b/tutorial2/testWrappedPoint.py
@@ -18,7 +18,9 @@ class Point(ctypes.Structure):
             self.y = y
         else:
             get_point = wrap_function(lib, 'get_point', Point, None)
-            self = get_point()
+            point = get_point()
+            self.x = point.x
+            self.y = point.y
 
         self.show_point_func = wrap_function(lib, 'show_point', None, [Point])
         self.move_point_func = wrap_function(lib, 'move_point', None, [Point])


### PR DESCRIPTION
Makefiles
=========

Issues:
- 'make clean' complained when files weren't found
- 'make clean' inconsistent between tutorial 1 and 2
- '.o' target did not work for vanilla make

Resolutions:
- Updated 'clean' target to use rm -rf so it doesn't error on
  nonexistent files

- Updated 'clean' target in tutorial2 to remove html like tutorial1

- Updated '.o' target to work with vanilla make by using % for filenames

testWrappedPoint.py
===================

Issue:
- testWrappedPoint.Point(lib) returns (0, 0)

Resolution:
- changed __init__ so __init__(lib) copies x and y from the C struct
  separately